### PR TITLE
 - Added algorithm header for MSVC2013 compatability

### DIFF
--- a/LibRawLite/internal/dcraw_common.cpp
+++ b/LibRawLite/internal/dcraw_common.cpp
@@ -7354,7 +7354,7 @@ void CLASS tiff_head (struct tiff_hdr *th, int full)
   strncpy (th->t_desc, desc, 512);
   strncpy (th->t_make, make, 64);
   strncpy (th->t_model, model, 64);
-  strcpy (th->soft, "dcraw v"VERSION);
+  strcpy (th->soft, "dcraw v" VERSION);
   t = gmtime (&timestamp);
   sprintf (th->date, "%04d:%02d:%02d %02d:%02d:%02d",
       t->tm_year+1900,t->tm_mon+1,t->tm_mday,t->tm_hour,t->tm_min,t->tm_sec);

--- a/LibRawLite/internal/defines.h
+++ b/LibRawLite/internal/defines.h
@@ -44,7 +44,7 @@
 #ifdef __CYGWIN__
 #include <io.h>
 #endif
-#ifdef WIN32
+#ifdef _WIN32
 #include <sys/utime.h>
 #include <winsock2.h>
 #pragma comment(lib, "ws2_32.lib")

--- a/LibRawLite/libraw/libraw_alloc.h
+++ b/LibRawLite/libraw/libraw_alloc.h
@@ -25,7 +25,7 @@
 
 #include <stdlib.h>
 #include <string.h>
-#ifdef WIN32
+#ifdef _WIN32
 #define bzero(p,sz) memset(p,0,sz)
 #endif
 

--- a/LibRawLite/libraw/libraw_types.h
+++ b/LibRawLite/libraw/libraw_types.h
@@ -23,7 +23,7 @@
 #ifndef _LIBRAW_TYPES_H
 #define _LIBRAW_TYPES_H
 
-#ifndef WIN32
+#ifndef _WIN32
 #include <sys/time.h>
 #endif
 #include <stdio.h>

--- a/LibRawLite/src/libraw_cxx.cpp
+++ b/LibRawLite/src/libraw_cxx.cpp
@@ -23,7 +23,7 @@
 #include <errno.h>
 #include <float.h>
 #include <math.h>
-#ifndef WIN32
+#ifndef _WIN32
 #include <netinet/in.h>
 #else
 #include <winsock2.h>

--- a/OpenEXR/IlmImf/ImfMisc.h
+++ b/OpenEXR/IlmImf/ImfMisc.h
@@ -45,6 +45,7 @@
 
 #include <ImfPixelType.h>
 #include <vector>
+#include <algorithm>
 #include <ImfCompressor.h>
 
 namespace Imf {


### PR DESCRIPTION
- Changed "WIN32" to "_WIN32", as the "WIN32" define is mingw only.
