### PR TITLE
Added missing swab function in Android

### DIFF
--- a/LibRawLite/internal/dcraw_common.cpp
+++ b/LibRawLite/internal/dcraw_common.cpp
@@ -16,6 +16,27 @@
 
 #line 267 "dcraw/dcraw.c"
 
+// Missing swab function in Android
+#if ANDROID
+	void swab(const void *from, void *to, ssize_t n)
+	{
+		if (n < 0)
+			return;
+
+		for (ssize_t i = 0; i < (n / 2) * 2; i += 2)
+		{
+#ifdef __arch__swab16
+			*((uint16_t*)to + i) = __arch__swab16(*((uint16_t*)from + i));
+#else
+			uint16_t val = *((uint16_t*)from + i);
+			uint16_t hi = (val & 0xFF) << 8;
+			uint16_t lo = (val >> 8) & 0xFF;
+			*((uint16_t*)to + i) = (hi | lo);
+#endif
+		}
+	}
+#endif
+
 #ifndef __GLIBC__
 char *my_memmem (char *haystack, size_t haystacklen,
 	      char *needle, size_t needlelen)

--- a/LibRawLite/internal/dcraw_common.cpp
+++ b/LibRawLite/internal/dcraw_common.cpp
@@ -7375,7 +7375,7 @@ void CLASS tiff_head (struct tiff_hdr *th, int full)
   strncpy (th->t_desc, desc, 512);
   strncpy (th->t_make, make, 64);
   strncpy (th->t_model, model, 64);
-  strcpy (th->soft, "dcraw v"VERSION);
+  strcpy(th->soft, "dcraw v");//VERSION);
   t = gmtime (&timestamp);
   sprintf (th->date, "%04d:%02d:%02d %02d:%02d:%02d",
       t->tm_year+1900,t->tm_mon+1,t->tm_mday,t->tm_hour,t->tm_min,t->tm_sec);

--- a/OpenEXR/IlmImf/ImfOutputFile.cpp
+++ b/OpenEXR/IlmImf/ImfOutputFile.cpp
@@ -59,6 +59,7 @@
 #include <fstream>
 #include <assert.h>
 
+#include <algorithm>
 
 namespace Imf {
 

--- a/OpenEXR/IlmImf/ImfScanLineInputFile.cpp
+++ b/OpenEXR/IlmImf/ImfScanLineInputFile.cpp
@@ -57,6 +57,7 @@
 #include <vector>
 #include <assert.h>
 
+#include <algorithm>
 
 namespace Imf {
 

--- a/OpenEXR/IlmImf/ImfTiledMisc.cpp
+++ b/OpenEXR/IlmImf/ImfTiledMisc.cpp
@@ -32,7 +32,6 @@
 //
 ///////////////////////////////////////////////////////////////////////////
 
-
 //-----------------------------------------------------------------------------
 //
 //	Miscellaneous stuff related to tiled files
@@ -44,6 +43,7 @@
 #include <ImfMisc.h>
 #include <ImfChannelList.h>
 
+#include <algorithm>
 
 namespace Imf {
 

--- a/OpenEXR/IlmImf/ImfTiledOutputFile.cpp
+++ b/OpenEXR/IlmImf/ImfTiledOutputFile.cpp
@@ -64,6 +64,7 @@
 #include <assert.h>
 #include <map>
 
+#include <algorithm>
 
 namespace Imf {
 

--- a/OpenEXR/OpenEXRConfig.h
+++ b/OpenEXR/OpenEXRConfig.h
@@ -1,3 +1,5 @@
+
+
 //
 // Define and set to 1 if the target system has POSIX thread support
 // and you want OpenEXR to use it for multithreaded file I/O.


### PR DESCRIPTION
Android doesn't provide a swab function, which causes the build to fail.